### PR TITLE
Corrected CoreFoundationVersion checking + Injection multiprogramming.

### DIFF
--- a/respring_simulator/respring_simulator.mm
+++ b/respring_simulator/respring_simulator.mm
@@ -43,18 +43,17 @@ void injectHeader() {
 }
 
 void inject(const char *udid, const char *device, BOOL _exit) {
+    if (device) {
+        printf("Respringing %s (%s) ...\n", udid, device);
+    } else {
+        printf("Respringing %s ...\n", !strcmp(udid, "booted") ? "a booted device" : udid);
+    }
     pid_t pid = fork();
     if (pid == 0) {
         system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", udid] UTF8String]);
-        if (device) {
-            printf("Respringing %s (%s) ...\n", udid, device);
-        } else {
-            printf("Respringing %s ...\n", !strcmp(udid, "booted") ? "a booted device" : udid);
-        }
         system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl stop com.apple.backboardd", udid] UTF8String]);
         exit(EXIT_SUCCESS);
     } else {
-        waitpid(pid, NULL, 0);
         if (_exit)
             exit(EXIT_SUCCESS);
 

--- a/respring_simulator/respring_simulator.mm
+++ b/respring_simulator/respring_simulator.mm
@@ -18,7 +18,7 @@ void printUsage() {
     printf("\t(Will respring iPhone 5 simulator running iOS 8.1)\n");
     printf("\nRespring the booted device with matching UDID:\n\n");
     printf("\trespring_simulator -i 5AA1C45D-DB69-4C52-A75B-E9BE9C7E7770\n");
-    printf("\t(Will respring simulator with UDID 5AA1C45D-DB69-4C52-A75B-E9BE9C7E7770)\n\n");
+    printf("\t(Will respring simulator with UDID 5AA1C45D-DB69-4C52-A75B-E9BE9C7E7770)\n");
     printf("\nRespring any booted simulator:\n\n");
     printf("\trespring_simulator all\n");
     printf("\n");
@@ -43,15 +43,22 @@ void injectHeader() {
 }
 
 void inject(const char *udid, const char *device, BOOL _exit) {
-    system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", udid] UTF8String]);
-    if (device) {
-        printf("Respringing %s (%s) ...\n", udid, device);
-    } else {
-        printf("Respringing %s ...\n", strcmp(udid, "booted") == 0 ? "a booted device" : udid);
-    }
-    system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl stop com.apple.backboardd", udid] UTF8String]);
-    if (_exit)
+    pid_t pid = fork();
+    if (pid == 0) {
+        system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", udid] UTF8String]);
+        if (device) {
+            printf("Respringing %s (%s) ...\n", udid, device);
+        } else {
+            printf("Respringing %s ...\n", !strcmp(udid, "booted") ? "a booted device" : udid);
+        }
+        system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl stop com.apple.backboardd", udid] UTF8String]);
         exit(EXIT_SUCCESS);
+    } else {
+        waitpid(pid, NULL, 0);
+        if (_exit)
+            exit(EXIT_SUCCESS);
+
+    }
 }
 
 void injectUDIDs(const char *udid, BOOL all) {

--- a/simject/simject.xm
+++ b/simject/simject.xm
@@ -34,41 +34,41 @@ NSArray *simjectGenerateDylibList() {
         NSDictionary *filter = [NSDictionary dictionaryWithContentsOfFile:plistPath];
         // A boolean that indicates if the dylib is already injected
         BOOL isInjected = NO;
-        // Decide whether to load the dylib from executables
         NSString *processName = [[NSProcessInfo processInfo] processName];
         // Nothing should be loaded into launchctl
         if ([processName isEqualToString:@"launchctl"])
             return nil;
-        for (NSString *process in filter[@"Filter"][@"Executables"]) {
-            if ([process isEqualToString:processName]) {
-                [dylibsToInject addObject:[[plistPath stringByDeletingPathExtension] stringByAppendingString:@".dylib"]];
-                isInjected = YES;
-                break;
+        // Decide whether to load the dylib from bundles
+        for (NSString *entry in filter[@"Filter"][@"Bundles"]) {
+            // If supported iOS versions are specified, we check it first
+            NSArray *supportedVersions = filter[@"CoreFoundationVersion"];
+            if (supportedVersions) {
+                if (supportedVersions.count != 1 && supportedVersions.count != 2)
+                    continue; // Supported versions are in wrong format, we should skip
+                if (supportedVersions.count == 1 && [supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber) {
+                    continue; // Doesn't meet lower bound
+                }
+                if (supportedVersions.count == 2 && ([supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber || [supportedVersions[1] doubleValue] < kCFCoreFoundationVersionNumber)) {
+                    continue; // Outside bounds
+                }
             }
+            // Now check if this bundle is loaded in this application or not
+            if (!CFBundleGetBundleWithIdentifier((CFStringRef)entry)) {
+                // Skip because this application doesn't load it
+                continue;
+            }
+            [dylibsToInject addObject:[[plistPath stringByDeletingPathExtension] stringByAppendingString:@".dylib"]];
+            isInjected = YES;
+            break;
         }
         if (!isInjected) {
-            // Decide whether to load the dylib from bundles
-            for (NSString *entry in filter[@"Filter"][@"Bundles"]) {
-                // If supported iOS versions are specified, we check it first
-                NSArray *supportedVersions = filter[@"CoreFoundationVersion"];
-                if (supportedVersions) {
-                    if (supportedVersions.count != 1 && supportedVersions.count != 2)
-                        continue; // Supported versions are in wrong format, we should skip
-                    if (supportedVersions.count == 1 && [supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber) {
-                        continue; // Doesn't meet lower bound
-                    }
-                    if (supportedVersions.count == 2 && ([supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber || [supportedVersions[1] doubleValue] < kCFCoreFoundationVersionNumber)) {
-                        continue; // Outside bounds
-                    }
+            // Decide whether to load the dylib from executables
+            for (NSString *process in filter[@"Filter"][@"Executables"]) {
+                if ([process isEqualToString:processName]) {
+                    [dylibsToInject addObject:[[plistPath stringByDeletingPathExtension] stringByAppendingString:@".dylib"]];
+                    isInjected = YES;
+                    break;
                 }
-                // Now check if this bundle is loaded in this application or not
-                if (!CFBundleGetBundleWithIdentifier((CFStringRef)entry)) {
-                    // Skip because this application doesn't load it
-                    continue;
-                }
-                [dylibsToInject addObject:[[plistPath stringByDeletingPathExtension] stringByAppendingString:@".dylib"]];
-                isInjected = YES;
-                break;
             }
         }
         if (!isInjected) {

--- a/simject/simject.xm
+++ b/simject/simject.xm
@@ -38,20 +38,20 @@ NSArray *simjectGenerateDylibList() {
         // Nothing should be loaded into launchctl
         if ([processName isEqualToString:@"launchctl"])
             return nil;
+        // If supported iOS versions are specified, we check it first
+        NSArray *supportedVersions = filter[@"CoreFoundationVersion"];
+        if (supportedVersions) {
+            if (supportedVersions.count != 1 && supportedVersions.count != 2)
+                continue; // Supported versions are in wrong format, we should skip
+            if (supportedVersions.count == 1 && [supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber) {
+                continue; // Doesn't meet lower bound
+            }
+            if (supportedVersions.count == 2 && ([supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber || [supportedVersions[1] doubleValue] < kCFCoreFoundationVersionNumber)) {
+                continue; // Outside bounds
+            }
+        }
         // Decide whether to load the dylib from bundles
         for (NSString *entry in filter[@"Filter"][@"Bundles"]) {
-            // If supported iOS versions are specified, we check it first
-            NSArray *supportedVersions = filter[@"CoreFoundationVersion"];
-            if (supportedVersions) {
-                if (supportedVersions.count != 1 && supportedVersions.count != 2)
-                    continue; // Supported versions are in wrong format, we should skip
-                if (supportedVersions.count == 1 && [supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber) {
-                    continue; // Doesn't meet lower bound
-                }
-                if (supportedVersions.count == 2 && ([supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber || [supportedVersions[1] doubleValue] < kCFCoreFoundationVersionNumber)) {
-                    continue; // Outside bounds
-                }
-            }
             // Now check if this bundle is loaded in this application or not
             if (!CFBundleGetBundleWithIdentifier((CFStringRef)entry)) {
                 // Skip because this application doesn't load it


### PR DESCRIPTION
CoreFoundationVersion checking must be the first to check when processing a dylib. We did it wrong the whole time for some reasons.

One minor change is the use of `fork()` when injecting dylibs to simulators. Making it paralell fashion should be good for performance.