### PR TITLE
Support for XPC binaries and iOS 7 runtimes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ debs/*
 _/*
 obj/*
 bin/*
+.DS_Store

--- a/respring_simulator/respring_simulator.mm
+++ b/respring_simulator/respring_simulator.mm
@@ -51,12 +51,12 @@ void inject(const char *udid, const char *device, BOOL _exit) {
     pid_t pid = fork();
     if (pid == 0) {
         system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", udid] UTF8String]);
+        system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv __XPC_DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", udid] UTF8String]);
         system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl stop com.apple.backboardd", udid] UTF8String]);
         exit(EXIT_SUCCESS);
     } else {
         if (_exit)
             exit(EXIT_SUCCESS);
-
     }
 }
 

--- a/respring_simulator/respring_simulator.mm
+++ b/respring_simulator/respring_simulator.mm
@@ -23,6 +23,8 @@ void printUsage() {
     printf("\t(Will respring simulator with UDID 5AA1C45D-DB69-4C52-A75B-E9BE9C7E7770)\n");
     printf("\nRespring any booted simulator:\n\n");
     printf("\trespring_simulator all\n");
+    printf("\nFor iOS 7 runtime (Xcode <= 6.2 w/o multi-simulator), -l flag is needed:\n\n");
+    printf("\trespring_simulator -l\n");
     printf("\n");
 }
 

--- a/simject/simject.xm
+++ b/simject/simject.xm
@@ -7,6 +7,11 @@
 static NSArray *blackListForFLEX = @[@"com.apple.Search.framework", @"com.apple.accessibility.AccessibilityUIServer"];
 
 NSArray *simjectGenerateDylibList() {
+    NSString *processName = [[NSProcessInfo processInfo] processName];
+    // launchctl, you are a special case
+    if ([processName isEqualToString:@"launchctl"]) {
+        return nil;
+    }
     // Create an array containing all the filenames in dylibDir (/opt/simject)
     NSError *e = nil;
     NSArray *dylibDirContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dylibDir error:&e];
@@ -34,10 +39,6 @@ NSArray *simjectGenerateDylibList() {
         NSDictionary *filter = [NSDictionary dictionaryWithContentsOfFile:plistPath];
         // A boolean that indicates if the dylib is already injected
         BOOL isInjected = NO;
-        NSString *processName = [[NSProcessInfo processInfo] processName];
-        // Nothing should be loaded into launchctl
-        if ([processName isEqualToString:@"launchctl"])
-            return nil;
         // If supported iOS versions are specified, we check it first
         NSArray *supportedVersions = filter[@"CoreFoundationVersion"];
         if (supportedVersions) {


### PR DESCRIPTION
Using `__XPC_DYLD_INSERT_LIBRARIES` extends simject capability to XPC binaries. This update also adds support for iOS 7 runtime (which is possible only under <= Mavericks and Xcode <= 6.2). One minor change this time is proper checking whether injection is done on launchctl. Though, the future release could be overriding `posix_spawn` of the aforementioned binary if someone actually figured out how to make it done.

One more thing, it turns out that Apple just forgot to include `launchctl` binary in the first iOS 11 runtime. The corresponding fixing code then has been deprecated/removed.