### PR TITLE
Prevent unwanted iOS 7 assumption and corrected CoreFoundationVersion rules.

### DIFF
--- a/respring_simulator/respring_simulator.mm
+++ b/respring_simulator/respring_simulator.mm
@@ -159,7 +159,7 @@ int main(int argc, char *const argv[]) {
         }
     }
     if (udidFlag || deviceFlag || versionFlag || iOS7) {
-        if (xcodeVersion < 800.0) {
+        if (xcodeVersion && xcodeVersion < 800.0) {
             printf("Warning: The selected Xcode version does not support multiple simulators, booting this device could cause the old one to stop (if not the same)\n");
         }
         if (!(udidFlag != (deviceFlag && versionFlag)) && !iOS7) {

--- a/simject/Makefile
+++ b/simject/Makefile
@@ -1,7 +1,6 @@
 TARGET = simulator:clang
 ARCHS = x86_64 i386
 DEBUG = 0
-GO_EASY_ON_ME = 1
 
 include $(THEOS)/makefiles/common.mk
 

--- a/simject/simject.xm
+++ b/simject/simject.xm
@@ -47,7 +47,7 @@ NSArray *simjectGenerateDylibList() {
             if (supportedVersions.count == 1 && [supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber) {
                 continue; // Doesn't meet lower bound
             }
-            if (supportedVersions.count == 2 && ([supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber || [supportedVersions[1] doubleValue] < kCFCoreFoundationVersionNumber)) {
+            if (supportedVersions.count == 2 && ([supportedVersions[0] doubleValue] > kCFCoreFoundationVersionNumber || [supportedVersions[1] doubleValue] <= kCFCoreFoundationVersionNumber)) {
                 continue; // Outside bounds
             }
         }


### PR DESCRIPTION
- Xcode version may return zero if `xcode-select` isn't used, thus we can't assume users are targeting iOS 7 (due to old algorithm)
- CoreFoundationVersion upper-bounds rule is exclusive