### PR TITLE
Support iOS 12 simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ARCHS = x86_64 i386
+ARCHS = x86_64
 DEBUG = 0
 
 all::
@@ -17,5 +17,6 @@ setup:: clean all
 	@rm -fv /opt/simject/simjectUIKit.dylib
 	@rm -fv /opt/simject/simjectUIKit.plist
 	@cp -v bin/simject.dylib /opt/simject
+	@codesign -f -s - /opt/simject/simject.dylib 
 	@cp -v simject/simject.plist /opt/simject
 	@echo "Done. Place your tweak's dynamic libraries and accompanying property lists inside /opt/simject to load them in the iOS Simulator."

--- a/respring_simulator/Makefile
+++ b/respring_simulator/Makefile
@@ -1,4 +1,5 @@
 TARGET = macosx:clang
+ARCHS = x86_64
 
 include $(THEOS)/makefiles/common.mk
 

--- a/simject/Makefile
+++ b/simject/Makefile
@@ -1,4 +1,4 @@
-TARGET = simulator:clang::5.0
+TARGET = simulator:clang::7.0
 
 include $(THEOS)/makefiles/common.mk
 


### PR DESCRIPTION
This pull adds support for the iOS 12 simulator by changing the following:

- Removing the `i386` architecture from simject and respring_simulator to allow building (fixes #38)
- Changing the deployment target from iOS 5.0 to 7.0 so that the deprecated, and now removed in IOS 12, libstdc++ is no longer used in favour of libc++
- Codesigning simject.dylib after copying setup to allow for loading in iOS 12