### PR TITLE
Codesigning related improvements

### DIFF
--- a/simject/simject.xm
+++ b/simject/simject.xm
@@ -97,6 +97,8 @@ NSArray *simjectGenerateDylibList() {
 	blackListForFLEX = @[@"com.apple.Search.framework", @"com.apple.accessibility.AccessibilityUIServer", @"com.apple.backboardd"];
 	// Inject any dylib meant to be run for this application
 	for (NSString *dylib in simjectGenerateDylibList()) {
-		HBLogDebug(@"Injecting %@ into %@: %d", dylib, NSBundle.mainBundle.bundleIdentifier, dlopen([dylib UTF8String], RTLD_LAZY | RTLD_GLOBAL) != NULL);
+		BOOL success = dlopen([dylib UTF8String], RTLD_LAZY | RTLD_GLOBAL) != NULL;
+		HBLogDebug(@"Injecting %@ into %@: %d.", dylib, NSBundle.mainBundle.bundleIdentifier, success);
+		if (!success) HBLogError(@"Couldn't inject %@ into %@:\n%s.", dylib, NSBundle.mainBundle.bundleIdentifier, dlerror());
 	}
 }

--- a/simjectExampleTweak/Makefile
+++ b/simjectExampleTweak/Makefile
@@ -19,5 +19,6 @@ ifneq (,$(filter x86_64 i386,$(ARCHS)))
 setup:: clean all
 	@rm -f /opt/simject/$(TWEAK_NAME).dylib
 	@cp -v $(THEOS_OBJ_DIR)/$(TWEAK_NAME).dylib /opt/simject/$(TWEAK_NAME).dylib
+	@codesign -f -s - /opt/simject/$(TWEAK_NAME).dylib
 	@cp -v $(PWD)/$(TWEAK_NAME).plist /opt/simject
 endif


### PR DESCRIPTION
This PR includes two changes:

 - In the event that an error occurs while loading a dylib for injection, it will now log the associated `dlerror()`, allowing for easier debugging.
- iOS 13 now requires a SHA256 signature. By default, binaries will be signed with SHA1. Added another line to the example Makefile to correct this.