### PR TITLE
Remove reliance on Prefix.pch (deprecated theos feature)

### DIFF
--- a/resim/resim.mm
+++ b/resim/resim.mm
@@ -7,6 +7,7 @@
 #include <string>
 #include <array>
 #include <regex>
+#include <Foundation/Foundation.h>
 
 using namespace std;
 

--- a/simject/simject.xm
+++ b/simject/simject.xm
@@ -1,4 +1,6 @@
 #import "../simject.h"
+#import <Foundation/Foundation.h>
+#import <HBLog.h>
 #import <dlfcn.h>
 
 static NSArray *blackListForFLEX;


### PR DESCRIPTION
This is a quick PR to fix compilation. 

Prefix.pch was removed from theos with iOS 14, and although it's still possible to make things compile, it's better to just properly import the needed headers.