### PR TITLE
Several Improvements, see comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 *.o
-.theos/*
-*/.theos/*
-**/.theos/*
+*/out/*
 debs/*
 *.deb
 *.dylib

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-export PREFIX = \033[1;34m>>\033[0m
-export SUB_PREFIX = \033[1;34m>>>\033[0m
+export PREFIX = \033[1;36m>>\033[0m
+export SUB_PREFIX = \033[1;36m>>>\033[0m
 export DONE_PREFIX = \033[1;32m>>\033[0m
 
 ifndef DYLIB_DIR

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,44 @@
-ARCHS = x86_64
-DEBUG = 0
+export PREFIX = \033[1;34m>>\033[0m
+export SUB_PREFIX = \033[1;34m>>>\033[0m
+export DONE_PREFIX = \033[1;32m>>\033[0m
+
+ifndef DYLIB_DIR
+  DYLIB_DIR = /opt/simject
+endif
+
+PARENT = $(shell dirname $(DYLIB_DIR))
+DD_NOT_EXISTS = $(shell test -d $(DYLIB_DIR); echo $$?)
+DD_NOT_WRITABLE = $(shell test -w $(PARENT); echo $$?)
+ifeq '$(DD_NOT_WRITABLE)' '1'
+NEED_ROOT = sudo
+NEED_ROOT_ASK = \033[1;32m>>\033[0m $(PARENT) is not writable. Using sudo.
+endif
+
+ifndef SYSROOT
+  SYSROOT = $(shell xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
+endif
+
+ifndef TRIPLE
+  TRIPLE = $(shell clang -print-target-triple)
+endif
 
 all::
-	@make -C resim
-	@make -C simject
+	@make -C resim build
+	@make -C simject build
 
 clean::
 	@rm -rfv bin
 	@make -C resim clean
 	@make -C simject clean
 
-setup:: clean all
-	@sudo mkdir -p /opt/simject
-	@sudo chown -Rv $(USER) /opt/simject
-# simjectUIKit has been deprecated.
-	@rm -fv /opt/simject/simjectUIKit.dylib
-	@rm -fv /opt/simject/simjectUIKit.plist
-	@cp -v bin/simject.dylib /opt/simject
-	@cp -v simject/simject.plist /opt/simject
-	@codesign -f -s - /opt/simject/simject.dylib 
-	@echo "Done. Place your tweak's dynamic libraries and accompanying property lists inside /opt/simject to load them in the iOS Simulator."
+setup:: all
+	@test -w $(PARENT) || echo "$(NEED_ROOT_ASK)"
+	@$(NEED_ROOT) mkdir -p $(DYLIB_DIR)
+	@$(NEED_ROOT) chown -R $(USER) $(DYLIB_DIR)
+	@echo "$(PREFIX) Copying Tweak Loader to $(DYLIB_DIR)"
+	@cp bin/simject.dylib $(DYLIB_DIR)
+	@cp simject/simject.plist $(DYLIB_DIR)
+	@echo "$(PREFIX) Installing resim"
+	@cp bin/resim /usr/local/bin/resim
+	@echo "$(DONE_PREFIX) Done. Place your tweak's dynamic libraries and accompanying property lists inside $(DYLIB_DIR) to load them in the iOS Simulator."
+	@echo "$(DONE_PREFIX) To load/reload tweaks, run 'resim' in your terminal"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ rm -rfv /tmp/simject_cycript /tmp/simject_cycript.zip
 
 8. If you encountered a problem while signing dylibs: `error: The specified item could not be found in the keychain.`, you can try to fix it by following [this](https://github.com/angelXwind/simject/issues/43#issuecomment-441659203) or [this](https://github.com/angelXwind/simject/issues/42#issuecomment-440920466).
 
+9. If you encoutered a problem while signing dylibs: `iPhone Developer: no identity found`, check out [this comment by iAlex11](https://github.com/angelXwind/simject/issues/55#issuecomment-615894757) (a neat way to get your identity is to run `security find-identity -p codesigning -v | head -n 1 | xargs | cut -d " " -f 2`).
+
 ### Final notes
 
 Please understand that that testing your tweaks on the iOS Simulator is not necessarily a 100% accurate representation of how it will behave on an actual iOS device.

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ simject is a command-line tool and iOS dynamic library that allows iOS tweak dev
 simject is BSD-licensed. See `LICENSE` for more information.
 
 ### Setting up the simject environment
-1. Ensure that you have the latest version of [Theos](https://github.com/theos/theos).
-2. Ensure that you have added your developer account in Xcode > Preferences > Accounts tab. This is required for code-signing some binaries used in simject.
-3. Ensure that there is "iOS Development" certificate listed once you clicked on "Manage Certificates", create one if there is not.
-4. Run these commands in a Terminal instance:
+1. Ensure that you have added your developer account in Xcode > Preferences > Accounts tab. This is required for code-signing some binaries used in simject.
+2. Ensure that there is "iOS Development" certificate listed once you clicked on "Manage Certificates", create one if there is not.
+3. Run these commands in a Terminal instance:
 
 ```
 git clone https://github.com/angelXwind/simject.git
 cd simject/
 make setup
 ```
+
 **Note:** During the process, you will be asked by `sudo` to enter your login password. Please note that it is normal for nothing to be displayed as you type your password.
 
 Now, we need to create a version of `CydiaSubstrate.framework` that has support for the `x86_64` (64-bit) and/or `i386` (32-bit) architectures.

--- a/resim/Makefile
+++ b/resim/Makefile
@@ -17,7 +17,7 @@ clean::
 
 build : resim.mm
 	@mkdir -p out
-	@echo "$(PREFIX) Compiling Resim for $(shell clang -print-target-triple)"
+	@echo "$(PREFIX) Compiling resim for $(shell clang -print-target-triple)"
 	@echo "$(SUB_PREFIX) Target Directory is $(DYLIB_DIR)"
 	@$(CXX) resim.mm $(ARCHFLAG) $(SYSROOTFLAG) -framework Foundation -DDYLIB_DIR=@\"$(DYLIB_DIR)\" -o out/resim
 	@echo "$(SUB_PREFIX) Signing..."

--- a/resim/Makefile
+++ b/resim/Makefile
@@ -18,7 +18,7 @@ clean::
 build : resim.mm
 	@mkdir -p out
 	@echo "$(PREFIX) Compiling resim for $(shell clang -print-target-triple)"
-	@echo "$(SUB_PREFIX) Target Directory is $(DYLIB_DIR)"
+	@echo "$(SUB_PREFIX) Target directory is $(DYLIB_DIR)"
 	@$(CXX) resim.mm $(ARCHFLAG) $(SYSROOTFLAG) -framework Foundation -DDYLIB_DIR=@\"$(DYLIB_DIR)\" -o out/resim
 	@echo "$(SUB_PREFIX) Signing..."
 	@codesign -f -s - out/resim

--- a/resim/Makefile
+++ b/resim/Makefile
@@ -1,15 +1,27 @@
-TARGET = macosx:clang::10.9
-ARCHS = x86_64
+ifndef DYLIB_DIR
+  DYLIB_DIR = /opt/simject
+endif
 
-include $(THEOS)/makefiles/common.mk
+ifndef ARCH
+  ARCHFLAG = 
+else
+  ARCHFLAG = -arch $(ARCH)
+endif
 
-TOOL_NAME = resim
-resim_FILES = resim.mm
-resim_CFLAGS = -Wno-deprecated-declarations
+ifdef SYSROOT
+  SYSROOTFLAG = -isysroot $(SYSROOT)
+endif
 
-include $(THEOS_MAKE_PATH)/tool.mk
+clean::
+	-@rm -r out/
 
-after-all::
-	@echo "Copying binaries..."
+build : resim.mm
+	@mkdir -p out
+	@echo "$(PREFIX) Compiling Resim for $(shell clang -print-target-triple)"
+	@echo "$(SUB_PREFIX) Target Directory is $(DYLIB_DIR)"
+	@$(CXX) resim.mm $(ARCHFLAG) $(SYSROOTFLAG) -framework Foundation -DDYLIB_DIR=@\"$(DYLIB_DIR)\" -o out/resim
+	@echo "$(SUB_PREFIX) Signing..."
+	@codesign -f -s - out/resim
+	@echo "$(SUB_PREFIX) Copying library..."
 	@mkdir -p ../bin
-	@cp -v $(THEOS_OBJ_DIR)/resim ../bin/
+	@cp out/resim ../bin

--- a/resim/resim.mm
+++ b/resim/resim.mm
@@ -7,6 +7,7 @@
 #include <string>
 #include <array>
 #include <regex>
+#include <Foundation/Foundation.h>
 
 using namespace std;
 
@@ -70,7 +71,7 @@ string exec(const char *cmd) {
 
 void injectHeader() {
 	globalHeader();
-	printf("Injecting appropriate dynamic libraries from /opt/simject...\n");
+	printf("Injecting appropriate dynamic libraries from %s...\n", [DYLIB_DIR UTF8String]);
 }
 
 void inject(const char *uuid, const char *device, const char *version, BOOL _exit, BOOL keepRunning) {
@@ -95,12 +96,12 @@ void inject(const char *uuid, const char *device, const char *version, BOOL _exi
 				}
 				uuid = strdup(suuid.c_str());
 			}
-			safe_system([[NSString stringWithFormat:@"plutil -replace bootstrap.child.DYLD_INSERT_LIBRARIES -string /opt/simject/simject.dylib %@/Library/Developer/CoreSimulator/Devices/%@/data/var/run/launchd_bootstrap.plist -s", NSHomeDirectory(), @(uuid)] UTF8String]);
+			safe_system([[NSString stringWithFormat:@"plutil -replace bootstrap.child.DYLD_INSERT_LIBRARIES -string %@/simject.dylib %@/Library/Developer/CoreSimulator/Devices/%@/data/var/run/launchd_bootstrap.plist -s", DYLIB_DIR, NSHomeDirectory(), @(uuid)] UTF8String]);
 			safe_system("killall launchd_sim");
 		} else {
-			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", uuid] UTF8String]);
-			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv __XPC_DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", uuid] UTF8String]);
-			safe_system([[NSString stringWithFormat:@"export SIMCTL_CHILD_DYLD_INSERT_LIBRARIES=/opt/simject/simject.dylib; xcrun simctl spawn %s launchctl stop com.apple.backboardd", uuid] UTF8String]);
+			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES %@/simject.dylib", uuid, DYLIB_DIR] UTF8String]);
+			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv __XPC_DYLD_INSERT_LIBRARIES %@/simject.dylib", uuid, DYLIB_DIR] UTF8String]);
+			safe_system([[NSString stringWithFormat:@"export SIMCTL_CHILD_DYLD_INSERT_LIBRARIES=%@/simject.dylib; xcrun simctl spawn %s launchctl stop com.apple.backboardd", DYLIB_DIR, uuid] UTF8String]);
 		}
 		exit(EXIT_SUCCESS);
 	} else {

--- a/resim/resim.mm
+++ b/resim/resim.mm
@@ -15,15 +15,15 @@ BOOL didHaveGlobalHeader = NO;
 
 void globalHeader() {
 	if (!didHaveGlobalHeader) {
-		printf("respring_simulator (C) 2016-2018 Karen/あけみ (angelXwind)\n");
+		printf("resim (C) 2016-2019 Karen/あけみ (angelXwind)\n");
 		didHaveGlobalHeader = YES;
 	}
 }
 
 void printUsage() {
 	globalHeader();
-	printf("\nUsage: resimmulator [options]\n");
-	printf("Example: resimmulator -d \"iPhone 5\" -v 8.1\n");
+	printf("\nUsage: resim [options]\n");
+	printf("Example: resim -d \"iPhone 5\" -v 8.1\n");
 	printf("\nAvailable options:\n");
 	printf("\t-h    Shows this usage dialog\n");
 	printf("\t-d    Specifies a device type\n");
@@ -33,17 +33,17 @@ void printUsage() {
 	printf("\tall   Resprings all booted iOS Simulators\n");
 	printf("\nExample usages:\n");
 	printf("\tRespring a booted device matching the specified device type and iOS version\n");
-	printf("\t\tresimmulator -d \"iPhone 5\" -v 8.1\n");
+	printf("\t\tresim -d \"iPhone 5\" -v 8.1\n");
 	printf("\tRespring any booted devices matching the specified iOS version\n");
-	printf("\t\tresimmulator -v 8.1\n");
+	printf("\t\tresim -v 8.1\n");
 	printf("\tRespring any booted devices matching the specified device type\n");
-	printf("\t\tresimmulator -d \"iPhone 5\"\n");
+	printf("\t\tresim -d \"iPhone 5\"\n");
 	printf("\tRespring a booted device with the specified UUID\n");
-	printf("\t\tresimmulator -i 5AA1C45D-DB69-4C52-A75B-E9BE9C7E7770\n");
+	printf("\t\tresim -i 5AA1C45D-DB69-4C52-A75B-E9BE9C7E7770\n");
 	printf("\tRespring all booted iOS Simulators\n");
-	printf("\t\tresimmulator all\n");
+	printf("\t\tresim all\n");
 	printf("\tRespring an iOS Simulator using the iOS 7 runtime (Xcode <= 6.2)\n");
-	printf("\t\tresimmulator -l\n");
+	printf("\t\tresim -l\n");
 }
 
 void safe_system(const char *cmd) {
@@ -100,7 +100,7 @@ void inject(const char *uuid, const char *device, const char *version, BOOL _exi
 		} else {
 			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", uuid] UTF8String]);
 			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl setenv __XPC_DYLD_INSERT_LIBRARIES /opt/simject/simject.dylib", uuid] UTF8String]);
-			safe_system([[NSString stringWithFormat:@"xcrun simctl spawn %s launchctl stop com.apple.backboardd", uuid] UTF8String]);
+			safe_system([[NSString stringWithFormat:@"export SIMCTL_CHILD_DYLD_INSERT_LIBRARIES=/opt/simject/simject.dylib; xcrun simctl spawn %s launchctl stop com.apple.backboardd", uuid] UTF8String]);
 		}
 		exit(EXIT_SUCCESS);
 	} else {

--- a/simject.h
+++ b/simject.h
@@ -1,1 +1,0 @@
-#define dylibDir @"/opt/simject"

--- a/simject/Makefile
+++ b/simject/Makefile
@@ -1,14 +1,33 @@
-TARGET = simulator:clang::7.0
-ARCHS = x86_64 i386
+ifndef DYLIB_DIR
+  DYLIB_DIR = /opt/simject
+endif
+# shouldn't need more than one unless it's being packaged
 
-include $(THEOS)/makefiles/common.mk
+ifndef ARCH
+  ARCHFLAG = 
+else
+  ARCHFLAG = -arch $(ARCH)
+endif
 
-TWEAK_NAME = simject
-simject_FILES = simject.xm
+ifndef SYSROOT
+  SYSROOT = $(shell xcode-select -p)/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
+endif
 
-include $(THEOS_MAKE_PATH)/tweak.mk
+ifndef TRIPLE
+  TRIPLE = $(shell clang -print-target-triple)
+endif
 
-after-all::
-	@echo "Copying binaries..."
+clean::
+	-@rm -r out/
+
+build : simject.m
+	@mkdir -p out
+	@echo "$(PREFIX) Compiling Simject for $(TRIPLE)"
+	@echo "$(SUB_PREFIX) Using SDK at $(SYSROOT)"
+	@echo "$(SUB_PREFIX) Target Directory is $(DYLIB_DIR)"
+	@$(CC) simject.m $(ARCHFLAG) -framework Foundation -isysroot $(SYSROOT) -target $(TRIPLE) -DDYLIB_DIR=@\"$(DYLIB_DIR)\" -dynamiclib -o out/simject.dylib
+	@echo "$(SUB_PREFIX) Signing..."
+	@codesign -f -s - out/simject.dylib
+	@echo "$(SUB_PREFIX) Copying library..."
 	@mkdir -p ../bin
-	@cp -v $(THEOS_OBJ_DIR)/simject.dylib ../bin/
+	@cp out/simject.dylib ../bin

--- a/simject/Makefile
+++ b/simject/Makefile
@@ -22,7 +22,7 @@ clean::
 
 build : simject.m
 	@mkdir -p out
-	@echo "$(PREFIX) Compiling Simject for $(TRIPLE)"
+	@echo "$(PREFIX) Compiling simject for $(TRIPLE)"
 	@echo "$(SUB_PREFIX) Using SDK at $(SYSROOT)"
 	@echo "$(SUB_PREFIX) Target Directory is $(DYLIB_DIR)"
 	@$(CC) simject.m $(ARCHFLAG) -framework Foundation -isysroot $(SYSROOT) -target $(TRIPLE) -DDYLIB_DIR=@\"$(DYLIB_DIR)\" -dynamiclib -o out/simject.dylib

--- a/simject/Makefile
+++ b/simject/Makefile
@@ -24,7 +24,7 @@ build : simject.m
 	@mkdir -p out
 	@echo "$(PREFIX) Compiling simject for $(TRIPLE)"
 	@echo "$(SUB_PREFIX) Using SDK at $(SYSROOT)"
-	@echo "$(SUB_PREFIX) Target Directory is $(DYLIB_DIR)"
+	@echo "$(SUB_PREFIX) Target directory is $(DYLIB_DIR)"
 	@$(CC) simject.m $(ARCHFLAG) -framework Foundation -isysroot $(SYSROOT) -target $(TRIPLE) -DDYLIB_DIR=@\"$(DYLIB_DIR)\" -dynamiclib -o out/simject.dylib
 	@echo "$(SUB_PREFIX) Signing..."
 	@codesign -f -s - out/simject.dylib

--- a/simject/simject.m
+++ b/simject/simject.m
@@ -1,5 +1,8 @@
-#import "../simject.h"
+#import <Foundation/Foundation.h>
 #import <dlfcn.h>
+#import <os/log.h>
+
+#define dylibDir DYLIB_DIR
 
 static NSArray *blackListForFLEX;
 
@@ -90,7 +93,7 @@ NSArray *simjectGenerateDylibList() {
 	return dylibsToInject;
 }
 
-%ctor {
+static __attribute__((constructor)) void SimjectInit (int argc, char **argv, char **envp) {
 	// Since many iOS tweak developers use FLEXible (or some variant of that tweak) to inspect the iOS Simulator...
 	// There are some processes that can crash when FLEXible is injected into them, significantly decreasing overall performance.
 	// These processes do indeed load UIKit as a library, but they do not actually present a GUI so there is no point in injecting FLEXible into them.
@@ -98,7 +101,7 @@ NSArray *simjectGenerateDylibList() {
 	// Inject any dylib meant to be run for this application
 	for (NSString *dylib in simjectGenerateDylibList()) {
 		BOOL success = dlopen([dylib UTF8String], RTLD_LAZY | RTLD_GLOBAL) != NULL;
-		HBLogDebug(@"Injecting %@ into %@: %d.", dylib, NSBundle.mainBundle.bundleIdentifier, success);
-		if (!success) HBLogError(@"Couldn't inject %@ into %@:\n%s.", dylib, NSBundle.mainBundle.bundleIdentifier, dlerror());
+		os_log_info(OS_LOG_DEFAULT, "Injecting %s into %s: %d.", [dylib UTF8String], [NSBundle.mainBundle.bundleIdentifier UTF8String], success);
+		if (!success) os_log_error(OS_LOG_DEFAULT, "Couldn't inject %s into %s:\n%s.", [dylib UTF8String], [NSBundle.mainBundle.bundleIdentifier UTF8String], dlerror());
 	}
 }


### PR DESCRIPTION
How running `make setup` looks now:
![image](https://user-images.githubusercontent.com/55725881/87214837-e13f0080-c2f5-11ea-9c05-7e243655ea08.png)

Removed:
* Replaced HBLog with the macros it evaluates to
* Removed simject.h as it was kinda pointless
* Removed theos dependency as it's entirely unnecessary
* Removed the empty control file required by theos

Changes/Additions:
* Dylib directory can now be specified at compile time using the envar DYLIB_DIR (e.g. make setup DYLIB_DIR=<your_dir_here>)
* Arch can be specified with the ARCH envar
* Sysroot can be specified with the SYSROOT envar
* simject.m is now compiled without logos, as it didn't use logos directives anyways.
* The main makefile only uses sudo if it can't already write to the directory
** Makefile also explains to user why it's asking for the root pass
* The main makefile now copies resim to /usr/local/bin/
* Makefile output is a bit prettier (and descriptive)