### PR TITLE
[fix] use setup routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ simject is BSD-licensed. See `LICENSE` for more information.
 sudo xcode-select -s /Applications/Xcode.app
 git clone https://github.com/akemin-dayo/simject.git
 cd simject/
-make all
+make setup
 ```
 
 **Note:** During the process, you may be asked by `sudo` to enter your login password. Please note that it is normal for nothing to be displayed as you type your password.


### PR DESCRIPTION
Updated the instructions to use `make setup` instead of `make all` for correct file placement. The previous command, `make all`, did not move `simject.dylib` and `simject.plist` to the `/opt/simject` directory, leading users to move them manually. This update ensures that both files are properly transferred to the appropriate directory as intended.